### PR TITLE
fix issue with leaving bomb and explode remaining bombs when you lose

### DIFF
--- a/browser/js/play/game-canvas.html
+++ b/browser/js/play/game-canvas.html
@@ -1,3 +1,3 @@
 <div ng-class="currentBomb || saveScore ? 'blurry' : 'not-blurry'" id="playGame"></div>
-<bomb-view ng-if="currentBomb" ></bomb-view>
+<bomb-view ng-if="currentBombActive()" ></bomb-view>
 <save-score ng-show="saveScore" ></save-score>

--- a/browser/js/play/gameCanvas.js
+++ b/browser/js/play/gameCanvas.js
@@ -7,8 +7,9 @@ app.directive('gameCanvas', function($window, $injector) {
       height: 600,
       timeLimit: 0,
       levelTimePad: 2000,
-      minBombExpiration: 1000 * 120,
+      minBombExpiration: 1000*120,
       desiredFps: 60,
+      customPlayerBombSeparate: 1,
       mapConfig: {
         mapA: {
           tilemap: 'simpleCity_Layer1',

--- a/browser/js/play/phaser/game.js
+++ b/browser/js/play/phaser/game.js
@@ -66,9 +66,8 @@ var RegexGame = RegexGame || {};
 
       //deal with collisions
       let playerStopped = () => player.stoppedFalling;
-      this.physics.arcade.collide(player, bombs, bombs.engage, playerStopped, this);
+      this.physics.arcade.collide(player, bombs, bombs.engage, null, this);
       this.physics.arcade.collide(player, this.map.obstacleLayer, null, playerStopped);
-      this.physics.arcade.collide(bombs, this.map.obstacleLayer, bombs.freeze);
 
       scoreText.text = 'Score: ' + this.game.scope.score;
       //did they win?
@@ -79,8 +78,9 @@ var RegexGame = RegexGame || {};
       }.bind(this), 1500);
       } //did they lose?
       else if(this.game.scope.numExploded > 0 || Date.now() >= RegexGame.gameConfig.timeLimit){
-        if(!this.groan.isPlaying) this.groan.play('playGroan');
-        bombs.forEachAlive(bomb => bomb.destroy());
+        bombs.forEachAlive(bomb => {
+          bomb.explosion = new Explosion(RegexGame.game, bomb.x, bomb.y, 'explosion', 'bombExplode');
+        });
         this.transitionState('GameOver');
       }
     },

--- a/browser/js/play/play.js
+++ b/browser/js/play/play.js
@@ -33,6 +33,12 @@ app.controller('PlayCtrl', function (highestScore, $state, $timeout, $log, $scop
     $scope.correct = 0; // are we still using this?
     $scope.counter = 0;
 
+    $scope.currentBombActive = function(){
+        var textBox = document.getElementById("text-answer");
+        if (textBox) textBox.focus();
+        return $scope.currentBomb;
+    }
+
     $scope.getNewQuestions = function(){
         QuestionFactory.getQuestions($scope.numQuestions, $scope.currentWave)
         .then(result => $scope.questions = result)
@@ -62,6 +68,7 @@ app.controller('PlayCtrl', function (highestScore, $state, $timeout, $log, $scop
         $scope.answered = false;
         $scope.correct = 0;
         player.canMove = true;
+        $scope.$evalAsync;
     }
 
     $scope.diffuse = function(answer, question, userid){
@@ -86,7 +93,7 @@ app.controller('PlayCtrl', function (highestScore, $state, $timeout, $log, $scop
                     document.getElementById("text-answer").value = "";
                     $scope.$evalAsync();
                 }, 1000);
-                
+
             } else {
                 diffused = true;
             }


### PR DESCRIPTION
(I think) there were two bugs with leaving the bomb. 

1: bombs that were stopped by obstacles consistently wouldn't let you leave the bomb if player collided from top or bottom. Not sure why. 
Solution: remove collision between bombs and obstacles (but left on for player). 

2: modifying the above helped, but still phaser collision didn't always separate the player and the bomb... leading to the same issue but a different cause. 
Solution: manually separate bomb and player, moving each 1 pixel away from the other. 

Fix for 2 led to a 3rd issue, where the bomb view form field didn't keep its focus. 
Solution: change ng-if logic to a function that returns if current bomb is set AND also sets the focus for the field (i.e. removed that piece from the phaser world)
